### PR TITLE
These creatures shouldn't be psionic.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -118,7 +118,6 @@
   - type: Grammar
     attributes:
       gender: male
-  - type: PotentialPsionic # Nyano
   - type: LanguageSpeaker
     speaks:
     - GalacticCommon

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -8,7 +8,6 @@
     interactSuccessString: hugging-success-generic
     interactSuccessSound: /Audio/Effects/thudswoosh.ogg
     messagePerceivedByOthers: hugging-success-generic-others
-  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic. 
 
 - type: entity
   name: skeleton pirate

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -16,7 +16,6 @@
     spawned:
     - id: FoodMeatHuman
       amount: 5
-  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
   - type: LanguageSpeaker
     speaks:
     - GalacticCommon


### PR DESCRIPTION
Essentially, MobBaseHuman being potential psionic meant that everyone automatically had the Latent Psychic trait by default, which isn't intended. 