### PR TITLE
Restore old IPC emotes and Include them on Harpies

### DIFF
--- a/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
@@ -1,73 +1,140 @@
 # species
 - type: emoteSounds
   id: SoundsHarpy
-  params:
-    variation: 0.125
   sounds:
     Scream:
       collection: HarpyScreams
+      params:
+        variation: 0.125
     Laugh:
       collection: HarpyLaugh
+      params:
+        variation: 0.125
     Sneeze:
       collection: MaleSneezes
+      params:
+        variation: 0.125
     Cough:
       collection: MaleCoughs
+      params:
+        variation: 0.125
     Sigh:
       collection: MaleSigh
+      params:
+        variation: 0.125
     Crying:
       collection: HarpyCry
+      params:
+        variation: 0.125
     Whistle:
       collection: Whistles
+      params:
+        variation: 0.125
     Hiss:
       collection: HarpyHisses
+      params:
+        variation: 0.125
     Meow:
       collection: HarpyMeows
+      params:
+        variation: 0.125
     Mew:
       collection: HarpyMews
+      params:
+        variation: 0.125
     Growl:
       collection: HarpyGrowls
+      params:
+        variation: 0.125
     Purr:
       collection: HarpyPurrs
+      params:
+        variation: 0.125
     HarpyRing:
       collection: HarpyRings
+      params:
+        variation: 0.125
     HarpyHonk:
       collection: HarpyHonks
+      params:
+        variation: 0.125
     HarpyPew:
       collection: HarpyPews
+      params:
+        variation: 0.125
     HarpyBang:
       collection: HarpyBangs
+      params:
+        variation: 0.125
     HarpyBeep:
       collection: HarpyBeeps
+      params:
+        variation: 0.125
     HarpyRev:
       collection: HarpyRevs
+      params:
+        variation: 0.125
     Click:
       collection: HarpyClicks
+      params:
+        variation: 0.125
     Chitter:
       collection: HarpyChitter
+      params:
+        variation: 0.125
     Squeak:
       collection: HarpySqueak
+      params:
+        variation: 0.125
     HarpyCaw:
       collection: HarpyCaws
+      params:
+        variation: 0.125
     Chirp:
       collection: HarpyChirps
+      params:
+        variation: 0.125
     Snarl:
       collection: VulpkaninSnarls
+      params:
+        variation: 0.125
     Bark:
       collection: VulpkaninBarks
+      params:
+        variation: 0.125
     Whine:
       collection: VulpkaninWhines
+      params:
+        variation: 0.125
     Howl:
       collection: VulpkaninHowls
+      params:
+        variation: 0.125
     Honk:
       collection: BikeHorn
+      params:
+        variation: 0.125
     Weh:
       collection: Weh
+      params:
+        variation: 0.125
     IPCWhirr:
       collection: IPCWhirrs
+      params:
+        variation: 0
     IPCBoop:
       collection: IPCBoops
+      params:
+        variation: 0
     IPCBeep:
         collection: IPCBeeps
+        params:
+          variation: 0
+    IPCPing:
+      collection: IPCPing
+      params:
+        variation: 0.125
+
 
 - type: emoteSounds
   id: MaleVulpkanin

--- a/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
@@ -62,6 +62,12 @@
       collection: BikeHorn
     Weh:
       collection: Weh
+    IPCWhirr:
+      collection: IPCWhirrs
+    IPCBoop:
+      collection: IPCBoops
+    IPCBeep:
+        collection: IPCBeeps
 
 - type: emoteSounds
   id: MaleVulpkanin

--- a/Resources/Prototypes/SoundCollections/ipc.yml
+++ b/Resources/Prototypes/SoundCollections/ipc.yml
@@ -14,7 +14,7 @@
   id: IPCBoops
   files:
   - /Audio/Voice/IPC/beep_500.ogg
-  -
+
 - type: soundCollection
   id: IPCPing
   files:

--- a/Resources/Prototypes/SoundCollections/ipc.yml
+++ b/Resources/Prototypes/SoundCollections/ipc.yml
@@ -14,3 +14,8 @@
   id: IPCBoops
   files:
   - /Audio/Voice/IPC/beep_500.ogg
+  -
+- type: soundCollection
+  id: IPCPing
+  files:
+  - /Audio/Effects/beep1.ogg

--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -388,11 +388,19 @@
       collection: CatHisses
     MonkeyScreeches:
       collection: MonkeyScreeches
-    RobotBeep:
-      path: /Audio/Effects/Cargo/buzz_two.ogg
     Sigh:
       path: /Audio/Voice/Talk/pai.ogg
     Crying:
       path: /Audio/EstacaoPirata/Voice/IPC/cry_robot_1.ogg
     Whistle:
       path: /Audio/Voice/Talk/pai.ogg
+    IPCWhirr:
+      collection: IPCWhirrs
+    IPCBoop:
+      collection: IPCBoops
+    IPCBeep:
+      collection: IPCBeeps
+    #Not the most organized way to reproduce this emote.
+    #But it does work because harpyBeep uses the same triggers as IPCBeep did.
+    HarpyBeep:
+      collection: IPCBeeps

--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -372,8 +372,6 @@
   sounds:
     Buzz:
       path: /Audio/Effects/Cargo/buzz_sigh.ogg
-      params:
-        variation: 0.125
     Scream:
       path: /Audio/EstacaoPirata/Voice/IPC/robot-scream.ogg
       params:
@@ -396,6 +394,8 @@
       path: /Audio/Voice/Talk/pai.ogg
     Crying:
       path: /Audio/EstacaoPirata/Voice/IPC/cry_robot_1.ogg
+      params:
+        variation: 0.125
     Whistle:
       path: /Audio/Voice/Talk/pai.ogg
     IPCWhirr:
@@ -404,14 +404,10 @@
       collection: IPCBoops
     IPCBeep:
       collection: IPCBeeps
-      params:
-        variation: 0
     #Not the most organized way to reproduce this emote.
     #But it does work because harpyBeep uses the same triggers as IPCBeep did.
     HarpyBeep:
       collection: IPCBeeps
-      params:
-        variation: 0
     IPCPing:
       collection: IPCPing
       params:

--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -369,15 +369,19 @@
 
 - type: emoteSounds
   id: UnisexIPC
-  params:
-    variation: 0.125
   sounds:
     Buzz:
       path: /Audio/Effects/Cargo/buzz_sigh.ogg
+      params:
+        variation: 0.125
     Scream:
       path: /Audio/EstacaoPirata/Voice/IPC/robot-scream.ogg
+      params:
+        variation: 0.125
     Laugh:
       path: /Audio/EstacaoPirata/Voice/IPC/robot-laugh_3.ogg
+      params:
+        variation: 0.125
     Chitter:
       path: /Audio/Voice/Talk/pai.ogg
     Squeak:
@@ -400,7 +404,15 @@
       collection: IPCBoops
     IPCBeep:
       collection: IPCBeeps
+      params:
+        variation: 0
     #Not the most organized way to reproduce this emote.
     #But it does work because harpyBeep uses the same triggers as IPCBeep did.
     HarpyBeep:
       collection: IPCBeeps
+      params:
+        variation: 0
+    IPCPing:
+      collection: IPCPing
+      params:
+          variation: 0.125

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -296,17 +296,21 @@
     - whirrs.
     - whirrs!
 
-# HarpyBeep
-# - type: emote
-  # id: IPCBeep
-  # category: Vocal
-  # chatMessages: [beeps]
-  # chatTriggers:
-    # - beep
-    # - beeps
-    # - beeps.
-    # - beeps!
-    
+
+# IPCs uses this one and HarpyBeep, they are the same. but trigger differently
+# This exists mostly so Harpies can also play the same sound as IPCs, solving the "beep" trigger conflict
+- type: emote
+  id: IPCBeep
+  category: Vocal
+  chatMessages: [beeps robotically]
+  chatTriggers:
+  - rbeep
+  - rbeep.
+  - rbeeps
+  - rbeeps.
+  - beeps robotically
+  - beeps robotically.
+
 - type: emote
   id: IPCBoop
   category: Vocal


### PR DESCRIPTION
## Deep Station 14 Pull Request
<!-- The text between the arrows are comments - they will not be visible on your PR. -->


## About the PR
<!-- What did you change in this PR? -->


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
IPCBeep was re-enabled but its triggers were changed so it would not conflict with HarpyBeep

"HarpyBeep" is nothing more than a trigger emote, that means it can be used to trigger the emote sound when the user uses one of the chatTriggers. There's no need to create another emote prototype. Instead, HarpyBeep was reused to play a different sound while they are triggered by IPCs.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/user-attachments/assets/3d09e96e-f082-4bc9-bd22-b07ed824d53d


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
