### PR TITLE
Update game_presets.yml

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -13,7 +13,7 @@
   id: SurvivalHellshift
   alias:
     - hellshift
-  showInVote: true
+  showInVote: false
   name: hellshift-title
   description: hellshift-description
   rules:


### PR DESCRIPTION
Disables Hellshift by admin request. It can still be obtainable through ForceGamemode, but will not appear in rotation.