### PR TITLE
Temporarily re-add hugging

### DIFF
--- a/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
+++ b/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
@@ -77,6 +77,12 @@ comp-window-knock = *knock knock*
 
 fence-rattle-success = *rattle*
 
+## Hugging players
+
+hugging-success-generic = You hug {THE($target)}.
+hugging-success-generic-others = { CAPITALIZE(THE($user)) } hugs {THE($target)}.
+hugging-success-generic-target = { CAPITALIZE(THE($user)) } hugs you.
+
 ## Other
 
 petting-success-tesla = You pet {THE($target)}, violating the laws of nature and physics.

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Player/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Player/vulpkanin.yml
@@ -5,6 +5,11 @@
   id: MobVulpkanin
   components:
     - type: CombatMode
+    - type: InteractionPopup
+      successChance: 1
+      interactSuccessString: hugging-success-generic
+      interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+      messagePerceivedByOthers: hugging-success-generic-others
     - type: MindContainer
       showExamineInfo: true
     - type: Input

--- a/Resources/Prototypes/Entities/Mobs/Player/arachne.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/arachne.yml
@@ -5,6 +5,11 @@
   id: MobArachne
   components:
   - type: CombatMode
+  - type: InteractionPopup
+    successChance: 1
+    interactSuccessString: hugging-success-generic
+    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+    messagePerceivedByOthers: hugging-success-generic-others
   - type: MindContainer
     showExamineInfo: true
   - type: Input

--- a/Resources/Prototypes/Entities/Mobs/Player/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/harpy.yml
@@ -5,6 +5,11 @@
   id: MobHarpy
   components:
   - type: CombatMode
+  - type: InteractionPopup
+    successChance: 1
+    interactSuccessString: hugging-success-generic
+    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+    messagePerceivedByOthers: hugging-success-generic-others
   - type: MindContainer
     showExamineInfo: true
   - type: Input

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -2,6 +2,12 @@
   save: false
   parent: BaseMobSkeletonPerson
   id: MobSkeletonPerson
+  components:
+  - type: InteractionPopup
+    successChance: 1
+    interactSuccessString: hugging-success-generic
+    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+    messagePerceivedByOthers: hugging-success-generic-others
 
 - type: entity
   name: skeleton pirate

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -180,6 +180,11 @@
   - type: Dna
   - type: MindContainer
     showExamineInfo: true
+  - type: InteractionPopup
+    successChance: 1
+    interactSuccessString: hugging-success-generic
+    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+    messagePerceivedByOthers: hugging-success-generic-others
   - type: CanHostGuardian
   - type: NpcFactionMember
     factions:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/Oni.yml
@@ -5,6 +5,11 @@
   id: MobOni
   components:
   - type: CombatMode
+  - type: InteractionPopup
+    successChance: 1
+    interactSuccessString: hugging-success-generic
+    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+    messagePerceivedByOthers: hugging-success-generic-others
   - type: MindContainer
     showExamineInfo: true
   - type: Input

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
@@ -5,6 +5,11 @@
   id: MobFelinid
   components:
   - type: CombatMode
+  - type: InteractionPopup
+    successChance: 1
+    interactSuccessString: hugging-success-generic
+    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+    messagePerceivedByOthers: hugging-success-generic-others
   - type: MindContainer
     showExamineInfo: true
   - type: Input


### PR DESCRIPTION
## About the PR
This PR reverts [Einstein-Engines#710](https://github.com/Simple-Station/Einstein-Engines/pull/710).

## Why / Balance
The upstream PR wasn't cleanly merged into DS14, and caused several species to break (notably, lamia and IPCs). So far, there isn't a good replacement (a very small variety of humanoid interactions), so I believe it's best to revert for now and let Rane cook.  
I don't believe the RP level in DS14 will get impacted as it is currently.

## Technical details
Literally just adds the components back.
When reverting this, you might want to keep the .ftl's in case something weird happens.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl: router
- tweak: Temporarily added hugging back due to problems with alternate species. This may remain permanently if nothing comes to replace it.