### PR TITLE
Update HumanoidCharacterProfile.cs

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -66,10 +66,10 @@ public sealed partial class HumanoidCharacterProfile : ICharacterProfile
     public string Customspeciename { get; set; } = "";
 
     [DataField]
-    public float Height { get; private set; }
+    public float Height { get; private set; } = 1f;
 
     [DataField]
-    public float Width { get; private set; }
+    public float Width { get; private set; } = 1f;
 
     [DataField]
     public int Age { get; set; } = 18;


### PR DESCRIPTION
Finally found it. HumanoidCharacterProfile was responsible for it, and in the update it was made to default to a Height and Width of 0 instead of 1, which when a character was spawned that did not otherwise define or touch the height sliders, would have the radius of their hitbox multiplied by 0.