### PR TITLE
Graytide Virus Event

### DIFF
--- a/Content.Server/StationEvents/Components/AirlockVirusRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/AirlockVirusRuleComponent.cs
@@ -1,0 +1,19 @@
+using Content.Server.StationEvents.Events;
+
+namespace Content.Server.StationEvents.Components;
+
+[RegisterComponent]
+public sealed partial class AirlockVirusRuleComponent : Component
+{
+    /// <summary>
+    ///     The maximum amount of time in seconds before each infected door is self-emagged.
+    /// </summary>
+    [DataField]
+    public int MinimumTimeToEmag = 30;
+
+    /// <summary>
+    ///     The maximum amount of time in seconds before each infected door is self-emagged.
+    /// </summary>
+    [DataField]
+    public int MaximumTimeToEmag = 120;
+}

--- a/Content.Server/StationEvents/Components/AirlockVirusTargetComponent.cs
+++ b/Content.Server/StationEvents/Components/AirlockVirusTargetComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Server.StationEvents.Components;
+
+[RegisterComponent]
+public sealed partial class AirlockVirusTargetComponent : Component { }

--- a/Content.Server/StationEvents/Events/AirlockVirusRule.cs
+++ b/Content.Server/StationEvents/Events/AirlockVirusRule.cs
@@ -1,0 +1,61 @@
+using Content.Server.StationEvents.Components;
+using Content.Shared.GameTicking.Components;
+using JetBrains.Annotations;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
+using Content.Server.Announcements.Systems;
+using Content.Server.GameTicking;
+using Content.Shared.Emag.Systems;
+using Robust.Shared.Timing;
+using Content.Server.Station.Components;
+using Content.Server.Station.Systems;
+
+namespace Content.Server.StationEvents.Events;
+
+[UsedImplicitly]
+public sealed class AirlockVirusRule : StationEventSystem<AirlockVirusRuleComponent>
+{
+    [Dependency] private readonly AnnouncerSystem _announcer = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly EmagSystem _emag = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly StationSystem _station = default!;
+
+    protected override void Started(EntityUid uid, AirlockVirusRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        var station = _gameTicker.GetSpawnableStations();
+        if (station is null)
+            return;
+        var stationGrids = new HashSet<EntityUid>();
+        foreach (var stations in station)
+        {
+            if (TryComp<StationDataComponent>(stations, out var data) && _station.GetLargestGrid(data) is { } grid)
+                stationGrids.Add(grid);
+        }
+
+        var query = EntityManager.EntityQueryEnumerator<AirlockVirusTargetComponent>();
+        List<EntityUid> airlocks = new();
+        while (query.MoveNext(out var airlockUid, out var _))
+        {
+            var parent = Transform(airlockUid).GridUid;
+            if (parent is null
+                || !stationGrids.Contains(parent!.Value))
+                continue;
+
+            airlocks.Add(airlockUid);
+        }
+        foreach (var target in airlocks)
+            Timer.Spawn(TimeSpan.FromSeconds(_random.NextDouble(component.MinimumTimeToEmag, component.MaximumTimeToEmag)), () =>
+                _emag.DoEmagEffect(uid, target));
+
+        _announcer.SendAnnouncement(
+            _announcer.GetAnnouncementId(args.RuleId),
+            Filter.Broadcast(),
+            "airlock-virus-event-announcement",
+            null,
+            Color.FromHex("#18abf5"),
+            null, null);
+    }
+}

--- a/Resources/Locale/en-US/station-events/events/airlock-virus.ftl
+++ b/Resources/Locale/en-US/station-events/events/airlock-virus.ftl
@@ -1,0 +1,1 @@
+airlock-virus-event-announcement = We have detected a GR4YT1D3 virus in the station's systems. Engineering staff are to inspect all station equipment for malfunctions and affect repairs if necessary.

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -360,6 +360,7 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsSecurity ]
+  - type: AirlockVirusTarget
 
 - type: entity
   parent: AirlockSecurity
@@ -369,6 +370,7 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsDetective ]
+  - type: AirlockVirusTarget
 
 #Delta V: Removed Brig Access
 #- type: entity
@@ -388,6 +390,7 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsSecurityLawyer ]
+  - type: AirlockVirusTarget
 
 - type: entity
   parent: AirlockSecurity
@@ -734,6 +737,7 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsSecurity ]
+  - type: AirlockVirusTarget
 
 - type: entity
   parent: AirlockSecurityGlass
@@ -743,6 +747,7 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsDetective ]
+  - type: AirlockVirusTarget
 
 #- type: entity
 #  parent: AirlockSecurityGlass
@@ -761,6 +766,7 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsSecurityLawyer ]
+  - type: AirlockVirusTarget
 
 - type: entity
   parent: AirlockSecurityGlass
@@ -1004,6 +1010,7 @@
       board: [ DoorElectronicsSecurity ]
   - type: Wires
     layoutId: AirlockSecurity
+  - type: AirlockVirusTarget
 
 - type: entity
   parent: AirlockMaintSecLocked

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -476,3 +476,15 @@
       maxOccurrences: 1 # this event has diminishing returns on interesting-ness, so we cap it
       weight: 5
     - type: MobReplacementRule
+
+- type: entity
+  id: AirlockVirusRule
+  parent: BaseGameRule
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: StationEvent
+      earliestStart: 15
+      minimumPlayers: 5
+      maxOccurrences: 1
+      weight: 3
+    - type: AirlockVirusRule


### PR DESCRIPTION
# Description

This is a new random event taken straight from SS13. The Graytide virus gradually emags every door in Security, except for the Armory and the Warden/HoS Office. Essentially, letting the prisoners out, and the graytiders in.

# Changelog

:cl:
- add: Added GR4T1D3 Virus Event
