### PR TITLE
Fix Gunther's Goggles

### DIFF
--- a/Resources/Prototypes/_ds14/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_ds14/Entities/Clothing/Eyes/glasses.yml
@@ -23,4 +23,5 @@
   - type: Clothing
     sprite: _ds14/Clothing/Eyes/sciencegoggles.rsi
   - type: EyeProtection
+    protectionTime: 10
   - type: FlashImmunity


### PR DESCRIPTION
The goggles weren't offering welding protection because they were inheriting from sunglasses, which have an eye protection rating of 5 instead of the default 10, thus they weren't protecting when welding.