### PR TITLE
More Reasonable Survival Times

### DIFF
--- a/Content.Server/StationEvents/Components/OscillatingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/OscillatingStationEventSchedulerComponent.cs
@@ -8,7 +8,7 @@ public sealed partial class OscillatingStationEventSchedulerComponent : Componen
 {
     // TODO cvars?
     [DataField]
-    public float MinChaos = 0.1f, MaxChaos = 15f;
+    public float MinChaos = 0.1f, MaxChaos = 5f;
 
     /// <summary>
     ///     The amount of chaos at the beginning of the round.

--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -7,13 +7,13 @@ public sealed partial class RampingStationEventSchedulerComponent : Component
     ///     The maximum number by which the event rate will be multiplied when shift time reaches the end time.
     /// </summary>
     [DataField]
-    public float ChaosModifier = 3f;
+    public float ChaosModifier = 2f;
 
     /// <summary>
     ///     The minimum number by which the event rate will be multiplied when the shift has just begun.
     /// </summary>
     [DataField]
-    public float StartingChaosRatio = 0.1f;
+    public float StartingChaosRatio = 0.5f;
 
     /// <summary>
     ///     The number by which all event delays will be multiplied. Unlike chaos, remains constant throughout the shift.

--- a/Content.Shared/CCVar/CCVars.Events.cs
+++ b/Content.Shared/CCVar/CCVars.Events.cs
@@ -15,12 +15,12 @@ public sealed partial class CCVars
     ///     Close to how long you expect a round to last, so you'll probably have to tweak this on downstreams.
     /// </summary>
     public static readonly CVarDef<float>
-        EventsRampingAverageEndTime = CVarDef.Create("events.ramping_average_end_time", 40f, CVar.ARCHIVE | CVar.SERVERONLY);
+        EventsRampingAverageEndTime = CVarDef.Create("events.ramping_average_end_time", 180f, CVar.ARCHIVE | CVar.SERVERONLY);
 
     /// <summary>
     ///     Average ending chaos modifier for the ramping event scheduler.
     ///     Max chaos chosen for a round will deviate from this
     /// </summary>
     public static readonly CVarDef<float>
-        EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 6f, CVar.ARCHIVE | CVar.SERVERONLY);
+        EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 2f, CVar.ARCHIVE | CVar.SERVERONLY);
 }

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -286,8 +286,8 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: OscillatingStationEventScheduler
-    minChaos: 0.8
-    maxChaos: 14
+    minChaos: 0.4
+    maxChaos: 4
     startingSlope: 0.2
     downwardsLimit: -0.35
     upwardsLimit: 0.4
@@ -299,8 +299,8 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: OscillatingStationEventScheduler
-    minChaos: 0.8
-    maxChaos: 8
+    minChaos: 0.2
+    maxChaos: 3
     startingSlope: -1
     downwardsLimit: -0.4
     upwardsLimit: 0.3


### PR DESCRIPTION
I'm setting a "More reasonable for MRP+" set of variables for the ramping scheduler gamemodes, as well as Irregular schedulers. The target round length will be 3 hours, with "Double event rate" at said maximum time, while starting out at half the event rate. Our weekend events should in general be more player & admin driven than just a "Nonstop random ventcritters fight".