### PR TITLE
Component implant system

### DIFF
--- a/Content.Shared/Implants/AddComponentsImplant/AddComponentsImplantComponent.cs
+++ b/Content.Shared/Implants/AddComponentsImplant/AddComponentsImplantComponent.cs
@@ -1,0 +1,26 @@
+﻿using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Implants.AddComponentsImplant;
+
+/// <summary>
+///     When added to an implanter will add the passed in components to the implanted entity.
+/// </summary>
+/// <remarks>
+///     Warning: Multiple implants with this component adding the same components will not properly remove components
+///     unless removed in the inverse order of their injection (Last in, first out).
+/// </remarks>
+[RegisterComponent]
+public sealed partial class AddComponentsImplantComponent : Component
+{
+    /// <summary>
+    ///     What components will be added to the entity. If the component already exists, it will be skipped.
+    /// </summary>
+    [DataField(required: true)]
+    public ComponentRegistry ComponentsToAdd;
+
+    /// <summary>
+    ///     What components were added to the entity after implanted. Is used to know what components to remove.
+    /// </summary>
+    [DataField]
+    public ComponentRegistry AddedComponents = new();
+}

--- a/Content.Shared/Implants/AddComponentsImplant/AddComponentsImplantSystem.cs
+++ b/Content.Shared/Implants/AddComponentsImplant/AddComponentsImplantSystem.cs
@@ -1,0 +1,39 @@
+﻿using Robust.Shared.Containers;
+using Content.Shared.Implants;
+
+namespace Content.Shared.Implants.AddComponentsImplant;
+
+public sealed class AddComponentsImplantSystem : EntitySystem
+{
+    [Dependency] private readonly IComponentFactory _factory = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<AddComponentsImplantComponent, ImplantImplantedEvent>(OnImplantImplantedEvent);
+        SubscribeLocalEvent<AddComponentsImplantComponent, EntGotRemovedFromContainerMessage>(OnRemove);
+    }
+
+    private void OnImplantImplantedEvent(Entity<AddComponentsImplantComponent> ent, ref ImplantImplantedEvent args)
+    {
+        if (args.Implanted is not {} target)
+            return;
+
+        foreach (var component in ent.Comp.ComponentsToAdd)
+        {
+            // Don't add the component if it already exists
+            if (EntityManager.HasComponent(target, _factory.GetComponent(component.Key).GetType()))
+                continue;
+
+            EntityManager.AddComponent(target, component.Value);
+            ent.Comp.AddedComponents.Add(component.Key, component.Value);
+        }
+    }
+
+    private void OnRemove(Entity<AddComponentsImplantComponent> ent, ref EntGotRemovedFromContainerMessage args)
+    {
+        EntityManager.RemoveComponents(args.Container.Owner, ent.Comp.AddedComponents);
+
+        // Clear the list so the implant can be reused.
+        ent.Comp.AddedComponents.Clear();
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -255,7 +255,7 @@
 # Example component implant
 - type: entity
   id: ComponentImplanter
-  suffix: telepathy
+  suffix: DEBUG
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -251,3 +251,12 @@
   components:
     - type: Implanter
       implant: MindShieldImplant
+
+# Example component implant
+- type: entity
+  id: ComponentImplanter
+  suffix: telepathy
+  parent: BaseImplantOnlyImplanter
+  components:
+    - type: Implanter
+      implant: ComponentImplant

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -325,3 +325,16 @@
    - type: Tag
      tags:
        - MindShield
+
+# Example component adding implant
+- type: entity
+  parent: BaseSubdermalImplant
+  id: ComponentImplant
+  name: Add A component DEBUG
+  description: Example component adding implant
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubdermalImplant
+  - type: AddComponentsImplant
+    componentsToAdd:
+    - type: Dispellable


### PR DESCRIPTION
# Description

Code handling for adding components to someone via implant. Takes care of all the lifting so that people can use just YML to make said items. Mostly for adding more customization and modding ease of use. 

No current implimentation besides a sample implant to show the YML format, as it was made for another server use, but it might be usefull to others.

Example implant adds the "dispellable" component when implanted, just to show syntax for YML.
```
  - type: AddComponentsImplant
    componentsToAdd:
    - type: Dispellable
```


# Changelog

:cl:
- add: Code files for implanting, removing, and checking for components as stated in YML
- fix: Fixed naming from old server
