### PR TITLE
Upped AME fuel to 1000 per jar from 500 per jar

### DIFF
--- a/Content.Shared/Ame/Components/AmeFuelContainerComponent.cs
+++ b/Content.Shared/Ame/Components/AmeFuelContainerComponent.cs
@@ -9,11 +9,11 @@ public sealed partial class AmeFuelContainerComponent : Component
     /// The amount of fuel in the container.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public int FuelAmount = 500;
+    public int FuelAmount = 1000;
 
     /// <summary>
     /// The maximum fuel capacity of the container.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public int FuelCapacity = 500;
+    public int FuelCapacity = 1000;
 }

--- a/Content.Shared/Ame/Components/AmeFuelContainerComponent.cs
+++ b/Content.Shared/Ame/Components/AmeFuelContainerComponent.cs
@@ -15,5 +15,5 @@ public sealed partial class AmeFuelContainerComponent : Component
     /// The maximum fuel capacity of the container.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public int FuelCapacity = 1000;
+    public int FuelCapacity = 500;
 }

--- a/Content.Shared/Ame/Components/AmeFuelContainerComponent.cs
+++ b/Content.Shared/Ame/Components/AmeFuelContainerComponent.cs
@@ -9,7 +9,7 @@ public sealed partial class AmeFuelContainerComponent : Component
     /// The amount of fuel in the container.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public int FuelAmount = 1000;
+    public int FuelAmount = 500;
 
     /// <summary>
     /// The maximum fuel capacity of the container.


### PR DESCRIPTION
# Description

This is my first time doing anything for this game but it seems to be correct.

Very simply, i have made all AME fuel jars to start with and have a maximum capacity of 1000.
This is better for low pop as you don't have to babysit it as much anymore.
---
# Changelog

:cl:
- Change: AME fuel to 1000 from 500