### PR TITLE
Fixes IPC Reboot Glitch

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -39,13 +39,16 @@
   - type: MobState
     allowedStates:
       - Alive
+      - Critical
       - Dead
   - type: MobThresholds
     thresholds:
       0: Alive
+      119.999: Critical # TO make it almost impossible
       120: Dead
     stateAlertDict:
       Alive: BorgHealth
+      Critical: BorgCrit
       Dead: BorgDead
   - type: TypingIndicator
     proto: robot


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Fixes the reboot ability not working for IPC's after they died. That's it. Y'all suck for not fixing this sooner. 

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---



# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed IPC inherent gameplay trait. Caused by eliminating the critical state from IPC's. Simply re-added the lines from an older version, ran as intended in Dev.

